### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ fabric.properties
 /php-cs-fixer.phar
 */Entity/*~
 .php_cs.cache
+.phpunit.result.cache

--- a/tests/PBurggraf/BinaryUtilities/BinaryUtilitiesTest.php
+++ b/tests/PBurggraf/BinaryUtilities/BinaryUtilitiesTest.php
@@ -35,7 +35,7 @@ class BinaryUtilitiesTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->virtualFileSystem = vfsStream::setup();
         $virtualFile = vfsStream::newFile('data.bin')


### PR DESCRIPTION
# Changed log
- The `.phpunit.result.cache` file is not under Git version control. Adding this file on `.gitignore` file.
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html), the method should be `protected function setUp(): void`.